### PR TITLE
Adds simple state tracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.15.0-buster
+ADD . /app
+WORKDIR /app
+ENV GO111MODULE=on
+RUN go mod download
+CMD go run cis.go


### PR DESCRIPTION
This approach is probably a dead-end, but perfect being the enemy of the good in this case I think I can make the case for including it anyway.  

Even if this never makes it into master, honestly.  As long as it's up here and tagged so that Golang can find it with "go get", we can use it in other projects.

The requirements for this to be findable with "go get" are that it needs to be tagged with a "semantic versioning" tag.  i.e. "v0.0.1" or some such.  "v0.0.0" is what go uses if it can't find a tag, so best not to use that.

Tagging it that way let's us write dockerfiles like:  

```Dockerfile
FROM golang:1.15.0-buster
ENV VERSION=v0.0.1
RUN go get github.com/tbotnz/cisgo-ios@${VERSION}
CMD go run github.com/tbotnz/cisgo-ios@${VERSION}
```