### PR TITLE
added build/release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+---
+name: release
+# pipeline triggers on push to master with the tag starting with `v` (semver enforcing)
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+jobs:
+  # even when there are no tests, test job will ensure that project builds successfully
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      - run: go test -cover ./...
+        env:
+          CGO_ENABLED: 0
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      # upx is the binary compressor
+      - name: Install upx
+        run: sudo apt update && sudo apt install upx -y
+
+      # uncomment if automated docker image build is enabled in .goreleaser.yml
+      # - name: Login to dockerhub
+      #   run: docker login -u user -p ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Release with goreleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist -f .goreleaser.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,60 @@
+project_name: cisgo-ios
+builds:
+  - env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    hooks:
+      post: upx "{{ .Path }}"
+# uncomment and modify if automated docker build/push is needed
+# dockers:
+#   - goos: linux
+#     goarch: amd64
+#     binaries:
+#       - cisgo-ios
+#     image_templates:
+#       - "hellt/cisgo-ios:latest"
+#       - 'hellt/cisgo-ios:{{ replace .Version "v" ""}}'
+#     dockerfile: Dockerfile
+#     skip_push: false
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+nfpms:
+  - id: cisgo-ios
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      amd64: x86_64
+      darwin: darwin
+      linux: linux
+    vendor: cisgo-ios
+    homepage: https://github.com/tbotnz/cisgo-ios
+    maintainer: tbotnz
+    description: Simple, small, fast, concurrent SSH server to emulate network equipment (i.e. Cisco IOS) for testing purposes.
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/local/bin


### PR DESCRIPTION
This PR adds build and release pipeline executed by Github actions.

The **build** process is done with [goreleaser](https://goreleaser.com/quick-start/), defined in `.goreleaser.yml` file and consists of:

* build of binaries for darwin/linux/windows OSes in amd64 architecture
* build of deb and rpm packages
* boilerplate for docker image build, left commented, since I dont know if you care for docker images on that stage.

The **release** part of `goreleaser` uploads the build artifacts to Github releases automatically after compressing them with `upx`.

### Execution conditions
The build/release pipeline is  triggered when push event is happened on master branch (merge or direct push) with a tag starting with `v`. If the tag is not created - the build won't happen.

### What does it bring?
With the automated build artefacts generation users will get the pre-built binaries for major OSes (as well as deb/rpm packages). They will be able to fetch/intsall them with a simple `curl+tar` combination or using the package managers. 