### PR TITLE
Input/Command Matching

### DIFF
--- a/fakedevices/genericFakeDevice.go
+++ b/fakedevices/genericFakeDevice.go
@@ -7,13 +7,16 @@ import (
 	"github.com/tbotnz/cisgo-ios/utils"
 )
 
+// SupportedCommands is a map of the commands a FakeDevice supports and it's corresponding output
+type SupportedCommands map[string]string
+
 // FakeDevice Struct for the device we will be simulating
 type FakeDevice struct {
 	Vendor            string            // Vendor of this fake device
 	Platform          string            // Platform of this fake device
 	Hostname          string            // Hostname of the fake device
 	Password          string            // Password of the fake device
-	SupportedCommands map[string]string // What commands this fake device supports
+	SupportedCommands SupportedCommands // What commands this fake device supports
 	ContextSearch     map[string]string // The available CLI prompt/contexts on this fake device
 	ContextHierarchy  map[string]string // The heiarchy of the available contexts
 }

--- a/utils/cmdmatch.go
+++ b/utils/cmdmatch.go
@@ -6,38 +6,95 @@ import (
 )
 
 // CmdMatch searches the provided supportedCommands to find a match for the provided userInput
-func CmdMatch(userInput string, supportedCommands map[string]string) (bool, string) {
+// Returns:
+//	match: bool
+// 	matchedCommand: string
+//  multipleMatches: bool
+//	error
+func CmdMatch(userInput string, supportedCommands map[string]string) (bool, string, bool, error) {
 
 	// Setup our return variables
 	match := false
 	matchedCmd := ""
+	multipleMatches := false
 
-	// Setup a Slice to hold any possibleMatches
-	possibleMatches := make([]string, len(supportedCommands))
+	// Setup a Map to hold any possibleMatches as keys, and the string.Fields as values
+	possibleMatches := make(map[string][]string)
 
 	// Turn our input string into fields
-	inputFields := strings.Fields(userInput)
+	// fmt.Printf("userInput: %s\n", userInput)
+	userInput = strings.ToLower(userInput) // Lowercase the user input
+	userInputFields := strings.Fields(userInput)
 
-	// Iterate through all the keys in the SupportedCommands map
-	for k := range supportedCommands {
-		commandFields := strings.Fields(k)
+	// Iterate through all the commands in the supportedCommands map
+	for supportedCommand := range supportedCommands {
+		supportedCommand := strings.ToLower(supportedCommand) // Lowercase our supported command
+		commandFields := strings.Fields(supportedCommand)
 
-		// Match field by field to discount any non matches
-		for _, inputField := range inputFields {
-			for _, commandField := range commandFields {
-				if strings.Contains(commandField, inputField) {
-					fmt.Printf("supportedCommand: %s\n", k)
-					possibleMatches = append(possibleMatches, k)
-					match = true
-				}
+		// Match against the 1st field in each command,
+		// and that the number of fields is the same,
+		// to find any possibleMatches.
+		if strings.Contains(commandFields[0], userInputFields[0]) &&
+			(len(commandFields) == len(userInputFields)) {
+			// fmt.Printf("supportedCommand: %s\n", k)
+			possibleMatches[supportedCommand] = commandFields
+		}
+	}
+
+	// Setup a map to hold our closestMatch(es)
+	closestMatch := make(map[string]struct{})
+
+	// Iterate through all possibleMatches to find the best match
+	// fmt.Printf("possibleMatches: %+v\n", possibleMatches)
+	for possibleMatch := range possibleMatches {
+
+		// First evaluate if we have an exact string match and break/return that
+		if userInput == possibleMatch {
+			closestMatch[possibleMatch] = struct{}{}
+			break
+		}
+
+		// Next, test if the entire input is contained within one of our commands
+		if strings.Contains(possibleMatch, userInput) {
+			closestMatch[possibleMatch] = struct{}{}
+			break
+		}
+
+		// Next delve into the fields and find best match
+		for p, possibleMatchField := range possibleMatches[possibleMatch] {
+			// fmt.Printf("possibleMatchField: %s\n", possibleMatchField)
+			if !strings.Contains(possibleMatchField, userInputFields[p]) {
+				// We did not get a match on this field, break
+				break
+			}
+			// fmt.Printf("%d\n", p)
+			// fmt.Printf("length of possibleMatch fields: %d\n", len(possibleMatches[possibleMatch]))
+			if p == (len(possibleMatches[possibleMatch]) - 1) {
+				closestMatch[possibleMatch] = struct{}{}
 			}
 		}
 	}
 
-	// Iterate through all possibleMatches to find the best match
-	for _, possibleMatch := range possibleMatches {
-		fmt.Printf("possibleMatch: %s\n", possibleMatch)
+	// Evaluate our closestMatch(es)
+	if len(closestMatch) > 1 {
+		// We had more than two matches to all conditions, return no match!
+		fmt.Printf("multiple matchedCmds: %s\n", closestMatch)
+		match = true
+		matchedCmd = ""
+		multipleMatches = true
+	} else if len(closestMatch) < 1 {
+		// We had _NO_ matches to any conditions, return no match!
+		// fmt.Printf("no matchedCmds\n")
+		match = false
+		matchedCmd = ""
+	} else {
+		match = true
+		for k := range closestMatch {
+			matchedCmd = k
+		}
+
 	}
 
-	return match, matchedCmd
+	// fmt.Printf("matchedCmd: %s\n\n", matchedCmd)
+	return match, matchedCmd, multipleMatches, nil
 }

--- a/utils/cmdmatch.go
+++ b/utils/cmdmatch.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CmdMatch searches the provided supportedCommands to find a match for the provided userInput
+func CmdMatch(userInput string, supportedCommands map[string]string) (bool, string) {
+
+	// Setup our return variables
+	match := false
+	matchedCmd := ""
+
+	// Setup a Slice to hold any possibleMatches
+	possibleMatches := make([]string, len(supportedCommands))
+
+	// Turn our input string into fields
+	inputFields := strings.Fields(userInput)
+
+	// Iterate through all the keys in the SupportedCommands map
+	for k := range supportedCommands {
+		commandFields := strings.Fields(k)
+
+		// Match field by field to discount any non matches
+		for _, inputField := range inputFields {
+			for _, commandField := range commandFields {
+				if strings.Contains(commandField, inputField) {
+					fmt.Printf("supportedCommand: %s\n", k)
+					possibleMatches = append(possibleMatches, k)
+					match = true
+				}
+			}
+		}
+	}
+
+	// Iterate through all possibleMatches to find the best match
+	for _, possibleMatch := range possibleMatches {
+		fmt.Printf("possibleMatch: %s\n", possibleMatch)
+	}
+
+	return match, matchedCmd
+}

--- a/utils/cmdmatch_test.go
+++ b/utils/cmdmatch_test.go
@@ -1,0 +1,50 @@
+package utils
+
+import "testing"
+
+func TestCmdMatch(t *testing.T) {
+
+	// Create a fake SupportedCommands map
+	mySupportedCommands := map[string]string{
+		"show version": "a version of stuff",
+		"show vlan":    "some vlan stuff",
+	}
+
+	input1 := "show version" // Should match "show version"
+	input2 := "sho ver"      // Should match "show version"
+	input3 := "sho vlan"     // Should match "show vlan"
+	input4 := "s v"          // Should return no match
+
+	match1, matchedCommand1 := CmdMatch(input1, mySupportedCommands)
+	if match1 != true {
+		t.Errorf(
+			"CmdMatch('%s', %v) = (%t, '%s'); want (true, 'a version of stuff')",
+			input1, mySupportedCommands, match1, matchedCommand1,
+		)
+	}
+
+	match2, matchedCommand2 := CmdMatch(input2, mySupportedCommands)
+	if match2 != true {
+		t.Errorf(
+			"CmdMatch('%s', %v) = (%t, '%s'); want (true, 'a version of stuff')",
+			input2, mySupportedCommands, match2, matchedCommand2,
+		)
+	}
+
+	match3, matchedCommand3 := CmdMatch(input3, mySupportedCommands)
+	if match3 != true {
+		t.Errorf(
+			"CmdMatch('%s', %v) = (%t, '%s); want (true, 'some vlan stuff')",
+			input3, mySupportedCommands, match3, matchedCommand3,
+		)
+	}
+
+	match4, matchedCommand4 := CmdMatch(input4, mySupportedCommands)
+	if match4 != false {
+		t.Errorf(
+			"CmdMatch('%s', %v) = (%t, '%s'); want (false, '')",
+			input4, mySupportedCommands, match4, matchedCommand4,
+		)
+	}
+
+}


### PR DESCRIPTION
Add the ability to evaluate any input and perform matching against the supported commands.

For example:

1. Input `sho ver` will now match `show version`
2. Input `s v` will match `show version` unless `show vlan` is also present, in which case it will fail due to being ambiguous still.