### PR TITLE
fixes #2: allowing for dynamic output/templating in transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,36 @@ go run cis.go -listners 1
 
 cisgo-ios is built modularly to support easy expansion or customization. Potential options for enhancement are outlined below.
 
+### Customized Output in Command Transcripts
+
+If you wish to modify elements of the transcript dynamically, for example the hostname,
+ you can instantiate templateable sections into your transcript.
+
+For example, in the packaged output of `show_version.txt` the hostname is listed as:
+
+```
+ROM: IOS-XE ROMMON
+{{.Hostname}} uptime is 4 hours, 55 minutes
+Uptime for this control processor is 4 hours, 56 minutes
+```
+
+Any value in the `fakedevices.FakeDevice` struct can be referenced in this way, today these are:
+
+```
+type FakeDevice struct {
+	Vendor            string            // Vendor of this fake device
+	Platform          string            // Platform of this fake device
+	Hostname          string            // Hostname of the fake device
+	Password          string            // Password of the fake device
+	SupportedCommands SupportedCommands // What commands this fake device supports
+	ContextSearch     map[string]string // The available CLI prompt/contexts on this fake device
+	ContextHierarchy  map[string]string // The heiarchy of the available contexts
+}
+```
+
+If you wish to template additional/different values, they will need to be added to the FakeDevice struct
+ and then instantiated in the transcript with a reference to `{{.MyNewAttribute}}`.
+
 ### Adding Additional Command Transcripts
 
 If you wish to add additional command transcripts, you simply need to include a plain text file in the appropriate

--- a/fakedevices/transcriptReader.go
+++ b/fakedevices/transcriptReader.go
@@ -1,0 +1,26 @@
+package fakedevices
+
+import (
+	"bytes"
+	"log"
+	"text/template"
+)
+
+// TranscriptReader parses a transcript file and populates any variables that may exist in it
+func TranscriptReader(transcript string, fakeDevice *FakeDevice) (string, error) {
+
+	// Setiup a template with our transcript
+	tmpl, err := template.New("fakeDeviceTemplate").Parse(transcript)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Setup a bytes buffer to accept the rendered template
+	var renderedTemplate bytes.Buffer
+
+	if err := tmpl.Execute(&renderedTemplate, fakeDevice); err != nil {
+		log.Fatal(err)
+	}
+
+	return renderedTemplate.String(), nil
+}

--- a/ssh_server/handlers/ciscohandlers.go
+++ b/ssh_server/handlers/ciscohandlers.go
@@ -77,8 +77,17 @@ func GenericCiscoHandler(myFakeDevice *fakedevices.FakeDevice) {
 			}
 
 			if match && !multipleMatches {
+				// Render the matched command output
+				output, err := fakedevices.TranscriptReader(
+					myFakeDevice.SupportedCommands[matchedCommand],
+					myFakeDevice,
+				)
+				if err != nil {
+					log.Fatal(err)
+				}
+
 				// Write the output of our matched command
-				term.Write(append([]byte(myFakeDevice.SupportedCommands[matchedCommand]), '\n'))
+				term.Write(append([]byte(output), '\n'))
 				continue
 			} else if multipleMatches {
 				// Multiple commands were matched, throw ambigious command

--- a/transcripts/cisco/csr1000v/show_running-config.txt
+++ b/transcripts/cisco/csr1000v/show_running-config.txt
@@ -7,7 +7,7 @@ service timestamps debug datetime msec
 service timestamps log datetime msec
 no service password-encryption
 !
-hostname herpa derpa
+hostname {{.Hostname}}
 !
 boot-start-marker
 boot-end-marker

--- a/transcripts/cisco/csr1000v/show_version.txt
+++ b/transcripts/cisco/csr1000v/show_version.txt
@@ -13,7 +13,7 @@ documentation or "License Notice" file accompanying the IOS-XE software,
 or the applicable URL provided on the flyer accompanying the IOS-XE
 software.
 ROM: IOS-XE ROMMON
-csr1000v uptime is 4 hours, 55 minutes
+{{.Hostname}} uptime is 4 hours, 55 minutes
 Uptime for this control processor is 4 hours, 56 minutes
 System returned to ROM by reload
 System image file is "bootflash:packages.conf"


### PR DESCRIPTION
This Commit will introduce template support into the command
 transcripts. This is done via the Golang `text/template`
 library.

For example, in the packaged output of `show_version.txt` the hostname is listed as:

```
ROM: IOS-XE ROMMON
{{.Hostname}} uptime is 4 hours, 55 minutes
Uptime for this control processor is 4 hours, 56 minutes
```

Any value in the `fakedevices.FakeDevice` struct can be referenced in this way, today these are:

```
type FakeDevice struct {
	Vendor            string            // Vendor of this fake device
	Platform          string            // Platform of this fake device
	Hostname          string            // Hostname of the fake device
	Password          string            // Password of the fake device
	SupportedCommands SupportedCommands // What commands this fake device supports
	ContextSearch     map[string]string // The available CLI prompt/contexts on this fake device
	ContextHierarchy  map[string]string // The heiarchy of the available contexts
}
```

Let me know if you have any questions!

-Brett